### PR TITLE
Optional parameter uri filter

### DIFF
--- a/DattoAPI/Private/apiCalls/ConvertTo-DattoQueryString.ps1
+++ b/DattoAPI/Private/apiCalls/ConvertTo-DattoQueryString.ps1
@@ -4,11 +4,11 @@ function ConvertTo-DattoQueryString {
         Converts uri filter parameters
 
     .DESCRIPTION
-        The Invoke-DattoRequest cmdlet converts & formats uri filter parameters
+        The ConvertTo-DattoQueryString cmdlet converts & formats uri filter parameters
         from a function which are later used to make the full resource uri for
         an API call
 
-        This is an internal helper function the ties in directly with the
+        This is an internal helper function that ties in directly with the
         Invoke-DattoRequest & any public functions that define parameters
 
     .PARAMETER uri_Filter
@@ -44,7 +44,7 @@ function ConvertTo-DattoQueryString {
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+    [Parameter(Mandatory = $false, ValueFromPipeline = $true)]
     [hashtable]$uri_Filter,
 
     [Parameter(Mandatory = $true)]
@@ -54,10 +54,6 @@ param(
     begin {}
 
     process {
-
-        if (-not $uri_Filter) {
-            return ""
-        }
 
         $excludedParameters =   'Debug', 'ErrorAction', 'ErrorVariable', 'InformationAction', 'InformationVariable',
                                 'OutBuffer', 'OutVariable', 'PipelineVariable', 'Verbose', 'WarningAction', 'WarningVariable',
@@ -69,20 +65,21 @@ param(
 
         $query_Parameters = [System.Web.HttpUtility]::ParseQueryString([String]::Empty)
 
-        ForEach ( $Key in $uri_Filter.GetEnumerator() ){
+        if ($uri_Filter) {
+            ForEach ( $Key in $uri_Filter.GetEnumerator() ){
 
-            if( $excludedParameters -contains $Key.Key ){$null}
-            elseif ( $Key.Value.GetType().IsArray ){
-                Write-Verbose "[ $($Key.Key) ] is an array parameter"
-                foreach ($Value in $Key.Value) {
-                    #$ParameterName = $Key.Key
-                    $query_Parameters.Add($Key.Key, $Value)
+                if( $excludedParameters -contains $Key.Key ){$null}
+                elseif ( $Key.Value.GetType().IsArray ){
+                    Write-Verbose "[ $($Key.Key) ] is an array parameter"
+                    foreach ($Value in $Key.Value) {
+                        $query_Parameters.Add($Key.Key, $Value)
+                    }
                 }
-            }
-            else{
-                $query_Parameters.Add($Key.Key, $Key.Value)
-            }
+                else{
+                    $query_Parameters.Add($Key.Key, $Key.Value)
+                }
 
+            }
         }
 
         # Build the request and load it with the query string.

--- a/docs/site/Internal/ConvertTo-DattoQueryString.md
+++ b/docs/site/Internal/ConvertTo-DattoQueryString.md
@@ -20,7 +20,7 @@ ConvertTo-DattoQueryString [-uri_Filter] <Hashtable> [-resource_Uri] <String> [<
 ```
 
 ## DESCRIPTION
-The Invoke-DattoRequest cmdlet converts & formats uri filter parameters
+The ConvertTo-DattoQueryString cmdlet converts & formats uri filter parameters
 from a function which are later used to make the full resource uri for
 an API call
 
@@ -58,7 +58,7 @@ Type: Hashtable
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 1
 Default value: None
 Accept pipeline input: True (ByValue)


### PR DESCRIPTION
fixes minor grammar and cmdlet naming in description

# Pull Request

## Description

Updates the `ConvertTo-DattoQueryString` function to allow optional **uri_Filter** parameter, to 

Fixes: https://github.com/Celerium/Datto-PowerShellWrapper/issues/9

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have reviewed the [Contributing](https://github.com/Celerium/Datto-PowerShellWrapper/blob/main/.github/CONTRIBUTING.md) guide
- [x] I am pulling to the **main** branch
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Confirmed does not include query parameter when not specified, will add this as single object or array as well when passed for query parameter
May need to confirm no other breaking changes in query filter for functions but should be behaving the same
